### PR TITLE
`getg` fix on arm64

### DIFF
--- a/getg_arm64.s
+++ b/getg_arm64.s
@@ -5,6 +5,6 @@
 #include "textflag.h"
 
 TEXT ·getg(SB), NOSPLIT, $0-4
-    MOVW    g, R8
-    MOVW    R8, ret+0(FP)
+    MOVD    g, R8
+    MOVD    R8, ret+0(FP)
     RET


### PR DESCRIPTION
A fix for `getg` on arm64: use 64-bit, not 32-bit moves