### PR TITLE
multiple small fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ root = true
 
 [*]
 # Change these settings to your own preference
-indent_style = space
+indent_style = tab
 indent_size = 2
 
 # We recommend you to keep these unchanged

--- a/goid.go
+++ b/goid.go
@@ -91,7 +91,7 @@ func findGidOffset(startOffset, maxOffset int) (offset int) {
 			offset = -1
 		}
 	}()
-	defer func() { debug.SetPanicOnFault(oldPanicOnFault) }()
+	defer debug.SetPanicOnFault(oldPanicOnFault)
 
 	if currGid != 0 && g != nil {
 		for offset = startOffset; offset < maxOffset; offset += gidSize {


### PR DESCRIPTION
- `gidFromG` catches segfaults now, as comment suggests it should
- added `FastGetGoIDAvailable` to tell if fast version of `GetGoID` is available
- changed spaces to tabs in the `.editorconfig`
- `go fmt`

There is no significant performance difference.

Before:
```
 ❯ go test -bench .
goos: darwin
goarch: arm64
pkg: github.com/observeinc/goid
BenchmarkSlowGid-10    	  636439	      1883 ns/op	      64 B/op	       2 allocs/op
BenchmarkFastGid-10    	592396588	         2.021 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetGoID-10    	587365522	         2.036 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/observeinc/goid	5.134s
```

After:
```
 ❯ go test -bench .
goos: darwin
goarch: arm64
pkg: github.com/observeinc/goid
BenchmarkSlowGid-10    	  638582	      1864 ns/op	      64 B/op	       2 allocs/op
BenchmarkFastGid-10    	595019316	         2.014 ns/op	       0 B/op	       0 allocs/op
BenchmarkGetGoID-10    	588988731	         2.036 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/observeinc/goid	5.046s
```